### PR TITLE
the use of "full" would create the incorrect XML

### DIFF
--- a/junos.go
+++ b/junos.go
@@ -396,9 +396,7 @@ func (j *Junos) GetConfig(section, format string) (string, error) {
 	command := fmt.Sprintf("<get-configuration format=\"%s\"><configuration>", format)
 	if section == "full" {
 		command += "</configuration></get-configuration>"
-	}
-
-	if nSecs >= 0 {
+	} else if nSecs >= 0 {
 		for i := 0; i < nSecs; i++ {
 			command += fmt.Sprintf("<%s>", secs[i])
 		}


### PR DESCRIPTION
Due to the way this code works using full would create a `<full/>` tag in the get-configuration tags.  This is not correct.  This pull requests fixes the bug. 
